### PR TITLE
Create test_toy_model.yaml

### DIFF
--- a/.github/workflows/test_toy_model.yaml
+++ b/.github/workflows/test_toy_model.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.10'
         cache: 'poetry'
         
     - name: Set up poetry

--- a/.github/workflows/test_toy_model.yaml
+++ b/.github/workflows/test_toy_model.yaml
@@ -23,4 +23,4 @@ jobs:
 
     - name: Run test
       run: |
-        poetry run python abctools/tests/test_abc_pipeline.py test
+        poetry run python abctools/tests/test_abc_pipeline.py

--- a/.github/workflows/test_toy_model.yaml
+++ b/.github/workflows/test_toy_model.yaml
@@ -1,0 +1,25 @@
+name: test_toy_model
+
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      
+    - name: Install poetry
+      run: pipx install poetry
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'poetry'
+      run: poetry install
+
+    - name: Run test
+      run: |
+        poetry run python abctools/tests/test_abc_pipeline.py test

--- a/.github/workflows/test_toy_model.yaml
+++ b/.github/workflows/test_toy_model.yaml
@@ -1,6 +1,5 @@
 name: test_toy_model
 
-
 on: [pull_request, workflow_dispatch]
 
 jobs:
@@ -9,15 +8,17 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-      
+
     - name: Install poetry
       run: pipx install poetry
-      
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.13'
         cache: 'poetry'
+        
+    - name: Set up poetry
       run: poetry install
 
     - name: Run test


### PR DESCRIPTION
## Overview
The ABCtools package currently has no testing to ensure changes do not impact package performance. We require at least one verification test that automatically verifies a simple calibration still works

## Changes
The PR introduces a single workflow `test_toy_model.yaml` that install poetry, uses the poetry instance to set up the python environment and cache the dependencies, and then run a test pipeline that uses the toy SIR model in the main package. Briefly, the test asserts that the results of ABC-SMC calibration were written correctly

## Requests
This PR should be approved despite pre-commit test failure if test_toy_model returns a success. Changes suggested by pre-commit will have to be made after this workflow is used to ensure the changes still allow code to function