### PR TITLE
Required SimulationBundle class to be imported outside `__init__.py`

### DIFF
--- a/abctools/__init__.py
+++ b/abctools/__init__.py
@@ -1,3 +1,1 @@
-from .abc_classes import SimulationBundle
-
 __all__ = ["abc_methods", "abc_classes", "plot_utils", "toy_model"]

--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 import polars as pl
 from scipy.stats import uniform
 
-from abctools import SimulationBundle, abc_methods, plot_utils, toy_model
+from abctools import abc_methods, plot_utils, toy_model
+from abctools.abc_classes import SimulationBundle
 
 # Set random seed
 random_seed = 12345


### PR DESCRIPTION
## Overview
Pre-commit throws errors for unused imports. The `__init__.py` typically imports classes from modules for use when the package is loaded in other projects, but doesn't used the classes within the script itself. There is a conflict between these two preferences, and we will side with pre-commit. We will therefore need to call the SimulationBundle class in scripts.

## Changes
Removed the call to import `SimulationBundle` from `.abc_classes` in the `__init__.py` script of the package. Made the import of `SimulationBundle` in the model test script more explicit as a separate line of code