### PR TITLE
Added collate function for distances results and inputs

### DIFF
--- a/abctools/tests/test_abc_pipeline.py
+++ b/abctools/tests/test_abc_pipeline.py
@@ -325,6 +325,30 @@ class TestABCPipeline(unittest.TestCase):
                 )
                 self.assertGreaterEqual(sim_bundle.n_accepted, self.n_required)
 
+            with self.subTest(
+                f"Collate accepted simulations, step #{step_number}"
+            ):
+                # Collate results from distance calculations
+                sim_bundle.collate_accepted()
+
+                # Ensure the accepted logical column is present
+                self.assertIn(
+                    "accepted_sim", sim_bundle.accept_results.columns
+                )
+
+                # Ensure the sum of TRUE counts in logical column is the number of accepted sims
+                self.assertEqual(
+                    sim_bundle.accept_results["accepted_sim"].sum(),
+                    sim_bundle.n_accepted,
+                )
+
+                # Check that distance values with accepted_sim == True are less than or equal to tolerance
+                accept_above_max = sim_bundle.accept_results.filter(
+                    pl.col("accepted_sim")
+                ).filter(pl.col("distance") > self.tolerance[step_number])
+
+                self.assertTrue(accept_above_max.is_empty())
+
             with self.subTest(f"Calculate weights, step #{step_number}"):
                 if step_number == 0:
                     # uniform weights on the initial step


### PR DESCRIPTION
## Overview
The target distances and list of accepted simulations during the ABC algorithm are separate attributes of the `SimulationBundle` and are therefore difficult to work with, requiring extra manipulation steps to compare the acceptance and distance as a function of the input parameters.

## Changes
Added the function `collate_accept` as a setter function in `SimulationBundle` that generates a polars `DataFrame` from the calculated `distances` dictionary and joins these results to the initial parameter inputs for quick diagnostics and manipulation. The `simulation` column is then checked for existing in the `accept` dictionary keys for fast filtering of the distance results.

This function is then tested in the toy model workflow developed earlier to ensure that the accepted logical column exists, that the number of `TRUE` values is equivalent to the number of accepted simulations, and that no simulations listed as accepted in the DataFrame have a distance greater than the threshold tolerance of the ABC-SMC step.

## Next steps
`Unittest` was used for testing to follow previous implementation. Analogous tests should be implemented in `Pytest`.